### PR TITLE
Implementing support for HTTP URLs in addition to file URLs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependency directories
 node_modules/
+package-lock.json
 
 # Internal directories
 .*/

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ const args = require('yargs')
     alias: 'i', describe: 'Set interactive mode', type: 'boolean', default: false
   })
 
+  .option('localfileurls', {
+    alias: 'l', describe: 'Use local file urls', type: 'boolean', default: false
+  })
+
   .option('port', {
     alias: 'p', describe: 'Set port (>= 0 and < 65536)', type: 'number', default: 8080
   })
@@ -42,4 +46,4 @@ const args = require('yargs')
 
 const variables = args.variables ? Object.assign({}, ...args.variables.map(i => i.split('=')).map(i => ({ [i[0]]: i[1] }))) : {};
 
-require('./server.js').VisualizationServer.initializeServer(args.port, args.interactive, args.default, args.folders, variables);
+require('./server.js').VisualizationServer.initializeServer(args.port, args.interactive, args.default, args.folders, args.localfileurls, variables);

--- a/inject.js
+++ b/inject.js
@@ -109,11 +109,13 @@
       const styleSheet = document.styleSheets[i];
       const myStyleSheet = [];
       myStyleSheets.push(myStyleSheet);
-      if (styleSheet.cssRules) {
-        for (let j = 0; j < styleSheet.cssRules.length; j += 1) {
-          myStyleSheet.push(styleSheet.cssRules[j].cssText);
+      try {
+        if (styleSheet.cssRules) {
+          for (let j = 0; j < styleSheet.cssRules.length; j += 1) {
+            myStyleSheet.push(styleSheet.cssRules[j].cssText);
+          }
         }
-      }
+      } catch (e) {}
     }
     changes.push(5, myStyleSheets);
   });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "puppeteer": "^0.10.2",
     "eslint": "^4.7.2",
     "file-uri-to-path": "^1.0.0",
-    "sync-request": "^6.0.0"
+    "sync-request": "^6.0.0",
+    "jsdom": "^12.2.0",
+    "jquery": "^3.3.1",
+    "express-http-proxy": "^1.4.0"
   },
   "devDependencies": {
     "eslint-config-airbnb-base": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "socket.io": "^2.0.3",
     "yargs": "^8.0.2",
     "puppeteer": "^0.10.2",
-    "eslint": "^4.7.2"
+    "eslint": "^4.7.2",
+    "file-uri-to-path": "^1.0.0",
+    "sync-request": "^6.0.0"
   },
   "devDependencies": {
     "eslint-config-airbnb-base": "^12.0.1",

--- a/server.js
+++ b/server.js
@@ -17,9 +17,9 @@ class VisualizationServer {
   /**
    * Create and initialize a server instance
    */
-  static initializeServer(port, interactive, defaultPage, folders, variables) {
+  static initializeServer(port, interactive, defaultPage, folders, localfileurls, variables) {
     puppeteer.launch({ args: ['--no-sandbox'] }).then((browser) => {
-      const visServer = new VisualizationServer(browser, port, interactive, defaultPage, folders, variables);
+      const visServer = new VisualizationServer(browser, port, interactive, defaultPage, folders, localfileurls, variables);
       visServer.startServer();
     });
   }
@@ -35,7 +35,7 @@ class VisualizationServer {
   /**
    * Private constructor (do not call it!)
    */
-  constructor(browser, port, interactive, defaultPage, folders, variables) {
+  constructor(browser, port, interactive, defaultPage, folders, localfileurls, variables) {
     this.app = express();
     this.http = http.Server(this.app);
     this.io = io(this.http);
@@ -45,6 +45,7 @@ class VisualizationServer {
     this.interactive = interactive;
     this.defaultPage = defaultPage;
     this.folders = folders;
+    this.localfileurls = localfileurls;
     this.variables = variables;
     this.resetStatus();
   }
@@ -136,8 +137,11 @@ class VisualizationServer {
               }
             });
             visualizationDocument = dom.window.document.documentElement.outerHTML;
-          } else {
+          } else if (this.localfileurls) {
             visualizationDocument = fs.readFileSync(this.url.startsWith('file') ? uri2path(this.url) : this.url, 'utf8');
+          } else {
+            res.send('Unable to load URL.');
+            return;
           }
           this.served = true;
           let string = "<script src='/socket.io/socket.io.js'></script>";

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const express = require('express');
 const http = require('http');
 const io = require('socket.io');
+const request = require('sync-request');
+const uri2path = require('file-uri-to-path');
 
 /**
   * VisualizationServer
@@ -116,7 +118,8 @@ class VisualizationServer {
       } else {
         try {
           let injectedCode = fs.readFileSync('inject.js', 'utf8');
-          let visualizationDocument = fs.readFileSync(this.url, 'utf8'); 
+          let visualizationDocument = this.url.startsWith('http') ? request('GET', this.url).getBody() :
+              fs.readFileSync(this.url.startsWith('file') ? uri2path(this.url) : this.url, 'utf8');
   
           this.served = true;
           let string = "<script src='/socket.io/socket.io.js'></script>";

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ class VisualizationServer {
    * Create and initialize a server instance
    */
   static initializeServer(port, interactive, defaultPage, folders, variables) {
-    puppeteer.launch().then((browser) => {
+    puppeteer.launch({ args: ['--no-sandbox'] }).then((browser) => {
       const visServer = new VisualizationServer(browser, port, interactive, defaultPage, folders, variables);
       visServer.startServer();
     });


### PR DESCRIPTION
@fvictor, Tuoris currently supports file URLs only. The improvement proposed here also adds support for HTTP URLs. I also need to check whether we should continue to support file URLs, because this method can be used to potentially expose any server-side file as there doesn't seem to be any validations. If we think we no longer need this I will update the PR limiting it only to HTTP URLs.

Best Regards.